### PR TITLE
Issue in stringbenchmarking.commons.ResourceReader.readFile(Class<?>, String)

### DIFF
--- a/src/main/java/stringbenchmarking/commons/ResourceReader.java
+++ b/src/main/java/stringbenchmarking/commons/ResourceReader.java
@@ -57,7 +57,7 @@ public class ResourceReader {
 	public String readFile(
 		Class<?> clazz,
 		String path) {
-		return readFileAsStream(clazz.getClassLoader(), new File(path));
+		return readFile(clazz.getClassLoader(), new File(path));
 	}
 
 	public String readFile(


### PR DESCRIPTION
fixing chaining stringbenchmarking.commons.ResourceReader.readFile(ClassLoader, String)